### PR TITLE
Allow a label to include a description

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Style/FrozenStringLiteralComment:
 
 Rails/Output:
   Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ set of labels.
 
 ## Initial Setup
 
-Ensure your team has a config file in the config directory. config/dls-labels.json can be used as a reference.
+Ensure your team has a config file in the config directory. config/dls-labels.json can be used as a reference. A label can be just the label name as a string, or a hash with `name` and `description` keys.
 
 Install external dependencies:
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ set of labels.
 
 ## Initial Setup
 
-Ensure your team has a config file in the config directory. config/dls-labels.json can be used as a reference. A label can be just the label name as a string, or a hash with `name` and `description` keys.
+Ensure your team has a config file in the config directory. config/dls-labels.json can be used as a reference. A label can be just the label name as a string, or a hash with `name` and `description` keys. A description cannot be longer than 100 characters.
 
 Install external dependencies:
 ```

--- a/config/dls-labels.json
+++ b/config/dls-labels.json
@@ -47,7 +47,10 @@
       "labels": [
         "feature",
         "enhancement",
-        "bug"
+        "bug",
+        { "name": "iteration",
+          "description": "continuing work, may be lightly specified and subject to team discussion before merge"
+        }
       ]
     },
     "size": {

--- a/lib/labeler.rb
+++ b/lib/labeler.rb
@@ -33,7 +33,8 @@ class Labeler
           client.add_label(repo, label[:name], category[:color], label.reject { |k| k == :name })
         end
       rescue Octokit::UnprocessableEntity => e
-        update_label(repo, label, category) if already_exists_error?(e.message)
+        raise e unless already_exists_error?(e.message)
+        update_label(repo, label, category)
       end
     end
   end

--- a/spec/config/test.json
+++ b/spec/config/test.json
@@ -8,7 +8,10 @@
       "color-name": "red",
       "color": "ff5050",
       "labels": [
-        "bug",
+        {
+          "name": "bug",
+          "description": "for bugs"
+        },
         "security"
       ]
     },

--- a/spec/labeler_spec.rb
+++ b/spec/labeler_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Labeler do
       labeler = described_class.new(client: client, config: config_file)
       repo = "sample_repo1"
       labeler.apply_labels(repo)
-      expect(client).to have_received(:add_label).with("sample_repo1", "bug", "ff5050")
+      expect(client).to have_received(:add_label).with("sample_repo1", "bug", "ff5050", { description: "for bugs" })
       expect(client).to have_received(:add_label).with("sample_repo1", "security", "ff5050")
       expect(client).to have_received(:add_label).with("sample_repo1", "refactor", "44cec0")
     end
@@ -73,6 +73,8 @@ RSpec.describe Labeler do
         labeler.apply_labels(repo)
         expect(client).to have_received(:add_label).with("sample_repo1", "refactor", "44cec0")
         expect(client).to have_received(:update_label).with("sample_repo1", "refactor", { color: "44cec0" })
+        expect(client).to have_received(:add_label).with("sample_repo1", "bug", "ff5050", { description: "for bugs" })
+        expect(client).to have_received(:update_label).with("sample_repo1", "bug", { color: "ff5050", description: "for bugs" })
       end
     end
   end
@@ -82,10 +84,10 @@ RSpec.describe Labeler do
       allow(client).to receive(:add_label)
       labeler = described_class.new(client: client, config: config_file)
       labeler.apply_labels_to_all
-      expect(client).to have_received(:add_label).with("some_org/example_1", "bug", "ff5050")
+      expect(client).to have_received(:add_label).with("some_org/example_1", "bug", "ff5050", { description: "for bugs" })
       expect(client).to have_received(:add_label).with("some_org/example_1", "security", "ff5050")
       expect(client).to have_received(:add_label).with("some_org/example_1", "refactor", "44cec0")
-      expect(client).to have_received(:add_label).with("some_org/example_2", "bug", "ff5050")
+      expect(client).to have_received(:add_label).with("some_org/example_2", "bug", "ff5050", { description: "for bugs" })
       expect(client).to have_received(:add_label).with("some_org/example_2", "security", "ff5050")
       expect(client).to have_received(:add_label).with("some_org/example_2", "refactor", "44cec0")
     end


### PR DESCRIPTION
still accept just a string label name

Add an 'iteration' label for DLS, with a description

closes #22
closes #56 
